### PR TITLE
Add Increment: Update Item Price

### DIFF
--- a/src/main/java/seedu/easylog/commands/itemscommands/ItemsUpdateCommand.java
+++ b/src/main/java/seedu/easylog/commands/itemscommands/ItemsUpdateCommand.java
@@ -17,6 +17,10 @@ import java.util.regex.Pattern;
 public class ItemsUpdateCommand extends ItemsCommand {
     /**
      * Updates a particular field of an item of interest in the system.
+     *
+     * @param extraDescription Any extra input from the user, this field should be empty
+     *                         in order to execute an update command successfully
+     * @param itemManager      item manager object which modifies items when necessary
      */
     public void execute(String extraDescription, ItemManager itemManager) throws WrongUpdateCommandException,
             WrongItemFieldException, EmptyItemIndexException, NonNumericItemIndexException, InvalidItemIndexException,

--- a/src/main/java/seedu/easylog/commands/itemscommands/ItemsUpdateCommand.java
+++ b/src/main/java/seedu/easylog/commands/itemscommands/ItemsUpdateCommand.java
@@ -1,0 +1,69 @@
+package seedu.easylog.commands.itemscommands;
+
+import seedu.easylog.common.Constants;
+import seedu.easylog.exceptions.WrongUpdateCommandException;
+import seedu.easylog.exceptions.WrongItemFieldException;
+import seedu.easylog.exceptions.EmptyItemIndexException;
+import seedu.easylog.exceptions.NonNumericItemIndexException;
+import seedu.easylog.exceptions.InvalidItemIndexException;
+import seedu.easylog.exceptions.NonNumericItemPriceException;
+import seedu.easylog.exceptions.EmptyItemPriceException;
+import seedu.easylog.exceptions.InvalidItemPriceException;
+import seedu.easylog.exceptions.NullItemPriceException;
+import seedu.easylog.item.ItemManager;
+
+import java.util.regex.Pattern;
+
+public class ItemsUpdateCommand extends ItemsCommand {
+    /**
+     * Updates a particular field of an item of interest in the system.
+     */
+    public void execute(String extraDescription, ItemManager itemManager) throws WrongUpdateCommandException,
+            WrongItemFieldException, EmptyItemIndexException, NonNumericItemIndexException, InvalidItemIndexException,
+            NonNumericItemPriceException, EmptyItemPriceException, InvalidItemPriceException, NullItemPriceException {
+        if (!extraDescription.isEmpty()) {
+            throw new WrongUpdateCommandException();
+        }
+
+        ui.askForItemIndex();
+        ItemsListCommand itemsListCommand = new ItemsListCommand();
+        itemsListCommand.execute(itemManager); // Show item list
+
+        String itemIndexInString = Constants.SCANNER.nextLine();
+        String itemIndexInStringWithoutSpaces = itemIndexInString.replace(" ", "");
+        if (itemIndexInStringWithoutSpaces.isEmpty()) {
+            throw new EmptyItemIndexException();
+        }
+
+        Pattern pattern = Pattern.compile(Constants.REGEX_NUMERIC_INPUT);
+        if (!pattern.matcher(itemIndexInString).matches()) { // If itemIndexInString is not numeric
+            throw new NonNumericItemIndexException();
+        }
+
+        int itemIndexInInt = Integer.parseInt(itemIndexInString) - Constants.ARRAY_OFFSET;
+
+        int size = itemManager.getSize();
+        if (itemIndexInInt < 0 || itemIndexInInt >= size) {
+            throw new InvalidItemIndexException();
+        }
+
+        ui.askForItemFieldToBeUpdated();
+        String itemField = Constants.SCANNER.nextLine();
+
+        String revisedItemPrice;
+
+        if (itemField.equals("p")) {
+            ui.askForRevisedItemPrice();
+            ItemsPromptPriceCommand itemsPromptPriceCommand = new ItemsPromptPriceCommand();
+
+            // Get revised item price while handling all possible exceptions
+            revisedItemPrice = itemsPromptPriceCommand.execute();
+        } else {
+            throw new WrongItemFieldException();
+        }
+
+        itemManager.setRevisedItemPrice(itemIndexInInt, revisedItemPrice);
+
+        ui.showUpdateItemPrice();
+    }
+}

--- a/src/main/java/seedu/easylog/common/Constants.java
+++ b/src/main/java/seedu/easylog/common/Constants.java
@@ -19,6 +19,7 @@ public class Constants {
     public static final String COMMAND_DELETE = "delete";
     public static final String COMMAND_LIST = "list";
     public static final String COMMAND_CLEAR = "clear";
+    public static final String COMMAND_UPDATE = "update";
 
     public static final String ITEM_NAME_AND_PRICE_SEPARATOR = ", S$";
     public static final String REGEX_NUMERIC_INPUT = "-?\\d+(\\.\\d+)?";

--- a/src/main/java/seedu/easylog/common/Messages.java
+++ b/src/main/java/seedu/easylog/common/Messages.java
@@ -77,10 +77,10 @@ public class Messages {
             + "Please input the item information again! :)";
     public static final String MESSAGE_WRONG_UPDATE_COMMAND = "OOPS!!! I'm sorry! I don't know what that means.\n"
             + "Do you mean \"items update\"? Alternatively, see \"items help\" for more information";
-    public static final String MESSAGE_ASK_FOR_ITEM_INDEX = "Below is the exhaustive list for all items. May I know" +
-            " which item should be updated? Please input the index of the item of interest only.";
-    public static final String MESSAGE_ASK_FOR_ITEM_FIELD_TO_BE_UPDATED = "What would you like to update, price " +
-            "or stock? (p/s)";
+    public static final String MESSAGE_ASK_FOR_ITEM_INDEX = "Below is the exhaustive list for all items. May I know"
+            + " which item should be updated? Please input the index of the item of interest only.";
+    public static final String MESSAGE_ASK_FOR_ITEM_FIELD_TO_BE_UPDATED = "What would you like to update, price "
+            + "or stock? (p/s)";
     public static final String MESSAGE_ASK_FOR_REVISED_ITEM_PRICE = "What is the revised item price?";
     public static final String MESSAGE_SHOW_UPDATE_ITEM_PRICE = "Done! I just updated the item price for you.";
     public static final String MESSAGE_WRONG_ITEM_FIELD_COMMAND = "OOPS!!! I'm sorry! I don't know what that means.\n"

--- a/src/main/java/seedu/easylog/common/Messages.java
+++ b/src/main/java/seedu/easylog/common/Messages.java
@@ -19,7 +19,7 @@ public class Messages {
     public static final String MESSAGE_GREETING = "Hello! I'm easyLog!\n"
             + "What can I do for you? Enter help to view commands.";
     public static final String MESSAGE_GOODBYE = "Bye. Thanks for using easyLog!";
-    public static final String MESSAGE_INVALID_COMMAND = "OOPS!!! I'm Sorry! I don't know what that means.\n"
+    public static final String MESSAGE_INVALID_COMMAND = "OOPS!!! I'm sorry! I don't know what that means.\n"
             + "Please input again! :)";
     public static final String MESSAGE_EMPTY_ITEM_NAME = "OOPS!!! The item name is missing!\n"
             + "Please complete the item information! :) ";
@@ -75,4 +75,20 @@ public class Messages {
             + "Please input the item information again! :)";
     public static final String MESSAGE_NON_NUMERIC_ITEM_PRICE = "OOPS!!! The input item price is not a number!\n"
             + "Please input the item information again! :)";
+    public static final String MESSAGE_WRONG_UPDATE_COMMAND = "OOPS!!! I'm sorry! I don't know what that means.\n"
+            + "Do you mean \"items update\"? Alternatively, see \"items help\" for more information";
+    public static final String MESSAGE_ASK_FOR_ITEM_INDEX = "Below is the exhaustive list for all items. May I know" +
+            " which item should be updated? Please input the index of the item of interest only.";
+    public static final String MESSAGE_ASK_FOR_ITEM_FIELD_TO_BE_UPDATED = "What would you like to update, price " +
+            "or stock? (p/s)";
+    public static final String MESSAGE_ASK_FOR_REVISED_ITEM_PRICE = "What is the revised item price?";
+    public static final String MESSAGE_SHOW_UPDATE_ITEM_PRICE = "Done! I just updated the item price for you.";
+    public static final String MESSAGE_WRONG_ITEM_FIELD_COMMAND = "OOPS!!! I'm sorry! I don't know what that means.\n"
+            + "Please input either \"p\" for (item) price or s for (item) stock.";
+    public static final String MESSAGE_INVALID_ITEM_INDEX = "OOPS!!! The item index is invalid!\n"
+            + "Please complete the item information! :)";
+    public static final String MESSAGE_EMPTY_ITEM_INDEX = "OOPS!!! The item index is empty!\n"
+            + "Please complete the item information! :)";
+    public static final String MESSAGE_NON_NUMERIC_ITEM_INDEX = "OOPS!!! The item index is non-numeric!\n"
+            + "Please complete the item information! :)";
 }

--- a/src/main/java/seedu/easylog/exceptions/EmptyItemIndexException.java
+++ b/src/main/java/seedu/easylog/exceptions/EmptyItemIndexException.java
@@ -1,0 +1,5 @@
+package seedu.easylog.exceptions;
+
+public class EmptyItemIndexException extends Throwable {
+    // no other code needed
+}

--- a/src/main/java/seedu/easylog/exceptions/InvalidItemIndexException.java
+++ b/src/main/java/seedu/easylog/exceptions/InvalidItemIndexException.java
@@ -1,0 +1,5 @@
+package seedu.easylog.exceptions;
+
+public class InvalidItemIndexException extends Throwable {
+    // no other code needed
+}

--- a/src/main/java/seedu/easylog/exceptions/NonNumericItemIndexException.java
+++ b/src/main/java/seedu/easylog/exceptions/NonNumericItemIndexException.java
@@ -1,0 +1,5 @@
+package seedu.easylog.exceptions;
+
+public class NonNumericItemIndexException extends Throwable {
+    // no other code needed
+}

--- a/src/main/java/seedu/easylog/exceptions/WrongItemFieldException.java
+++ b/src/main/java/seedu/easylog/exceptions/WrongItemFieldException.java
@@ -1,0 +1,5 @@
+package seedu.easylog.exceptions;
+
+public class WrongItemFieldException extends Throwable {
+    // no other code needed
+}

--- a/src/main/java/seedu/easylog/exceptions/WrongUpdateCommandException.java
+++ b/src/main/java/seedu/easylog/exceptions/WrongUpdateCommandException.java
@@ -1,0 +1,5 @@
+package seedu.easylog.exceptions;
+
+public class WrongUpdateCommandException extends Throwable {
+    // no other code needed
+}

--- a/src/main/java/seedu/easylog/item/Item.java
+++ b/src/main/java/seedu/easylog/item/Item.java
@@ -34,4 +34,11 @@ public class Item {
     public String getDeleteItemMessage() {
         return "Got it! The item [" + itemName + "] is deleted.";
     }
+
+    /**
+     * Sets item price.
+     */
+    public void setItemPrice(String itemPrice) {
+        this.itemPrice = itemPrice;
+    }
 }

--- a/src/main/java/seedu/easylog/item/Item.java
+++ b/src/main/java/seedu/easylog/item/Item.java
@@ -36,7 +36,7 @@ public class Item {
     }
 
     /**
-     * Sets item price.
+     * Sets the price of an item of interest.
      */
     public void setItemPrice(String itemPrice) {
         this.itemPrice = itemPrice;

--- a/src/main/java/seedu/easylog/item/ItemManager.java
+++ b/src/main/java/seedu/easylog/item/ItemManager.java
@@ -85,5 +85,14 @@ public class ItemManager {
         int index = getSize() - Constants.ARRAY_OFFSET;
         return getItem(index);
     }
+
+    /**
+     * Sets the price of an item specified by its index to
+     * be the revised one.
+     */
+    public void setRevisedItemPrice(int itemIndex, String revisedItemPrice) {
+        Item itemToBeUpdated = getItem(itemIndex);
+        itemToBeUpdated.setItemPrice(revisedItemPrice);
+    }
 }
 

--- a/src/main/java/seedu/easylog/parser/ItemsParser.java
+++ b/src/main/java/seedu/easylog/parser/ItemsParser.java
@@ -1,9 +1,26 @@
 package seedu.easylog.parser;
 
-import seedu.easylog.commands.itemscommands.*;
+import seedu.easylog.commands.itemscommands.ItemsAddCommand;
+import seedu.easylog.commands.itemscommands.ItemsDeleteCommand;
+import seedu.easylog.commands.itemscommands.ItemsClearCommand;
+import seedu.easylog.commands.itemscommands.ItemsListCommand;
+import seedu.easylog.commands.itemscommands.ItemsUpdateCommand;
 import seedu.easylog.common.Constants;
 
-import seedu.easylog.exceptions.*;
+import seedu.easylog.exceptions.EmptyNameException;
+import seedu.easylog.exceptions.NonNumericItemPriceException;
+import seedu.easylog.exceptions.InvalidItemPriceException;
+import seedu.easylog.exceptions.EmptyItemPriceException;
+import seedu.easylog.exceptions.NullItemPriceException;
+import seedu.easylog.exceptions.EmptyNumberException;
+import seedu.easylog.exceptions.InvalidNumberException;
+import seedu.easylog.exceptions.ItemListAlreadyClearedException;
+import seedu.easylog.exceptions.WrongUpdateCommandException;
+import seedu.easylog.exceptions.InvalidItemIndexException;
+import seedu.easylog.exceptions.EmptyItemIndexException;
+import seedu.easylog.exceptions.NonNumericItemIndexException;
+import seedu.easylog.exceptions.WrongItemFieldException;
+
 import seedu.easylog.item.ItemManager;
 
 /**

--- a/src/main/java/seedu/easylog/parser/ItemsParser.java
+++ b/src/main/java/seedu/easylog/parser/ItemsParser.java
@@ -1,19 +1,9 @@
 package seedu.easylog.parser;
 
-import seedu.easylog.commands.itemscommands.ItemsAddCommand;
-import seedu.easylog.commands.itemscommands.ItemsDeleteCommand;
-import seedu.easylog.commands.itemscommands.ItemsClearCommand;
-import seedu.easylog.commands.itemscommands.ItemsListCommand;
+import seedu.easylog.commands.itemscommands.*;
 import seedu.easylog.common.Constants;
 
-import seedu.easylog.exceptions.EmptyNameException;
-import seedu.easylog.exceptions.NonNumericItemPriceException;
-import seedu.easylog.exceptions.InvalidItemPriceException;
-import seedu.easylog.exceptions.EmptyItemPriceException;
-import seedu.easylog.exceptions.NullItemPriceException;
-import seedu.easylog.exceptions.EmptyNumberException;
-import seedu.easylog.exceptions.InvalidNumberException;
-import seedu.easylog.exceptions.ItemListAlreadyClearedException;
+import seedu.easylog.exceptions.*;
 import seedu.easylog.item.ItemManager;
 
 /**
@@ -60,6 +50,29 @@ public class ItemsParser extends Parser {
                 new ItemsClearCommand().execute(itemManager);
             } catch (ItemListAlreadyClearedException e) {
                 ui.showAlreadyClearedItemList();
+            }
+            break;
+        case (Constants.COMMAND_UPDATE):
+            try {
+                new ItemsUpdateCommand().execute(itemsArg, itemManager);
+            } catch (WrongUpdateCommandException e) {
+                ui.showWrongUpdateCommand();
+            } catch (WrongItemFieldException e) {
+                ui.showWrongItemField();
+            } catch (InvalidItemIndexException e) {
+                ui.showInvalidItemIndex();
+            } catch (EmptyItemIndexException e) {
+                ui.showEmptyItemIndex();
+            } catch (NonNumericItemIndexException e) {
+                ui.showNonNumericItemIndex();
+            } catch (EmptyItemPriceException e) {
+                ui.showEmptyItemPrice();
+            } catch (NullItemPriceException e) {
+                ui.showNullItemPrice();
+            } catch (NonNumericItemPriceException e) {
+                ui.showNonNumericItemPrice();
+            } catch (InvalidItemPriceException e) {
+                ui.showInvalidItemPrice();
             }
             break;
         default:

--- a/src/main/java/seedu/easylog/ui/Ui.java
+++ b/src/main/java/seedu/easylog/ui/Ui.java
@@ -224,4 +224,78 @@ public class Ui {
     public void showEmptyItemPrice() {
         System.out.println(Messages.MESSAGE_EMPTY_ITEM_PRICE);
     }
+
+    /**
+     * Prints a message to notify the user that the update command is entered wrongly.
+     * This means the user should input "items update" exactly if he / she
+     * really wants to execute an update command for any item of interest.
+     */
+    public void showWrongUpdateCommand() {
+        System.out.println(Messages.MESSAGE_WRONG_UPDATE_COMMAND);
+    }
+
+    /**
+     * Prints a message to ask the user for the index of the item
+     * in order for a field of the item to be updated later.
+     */
+    public void askForItemIndex() {
+        System.out.println(Messages.MESSAGE_ASK_FOR_ITEM_INDEX);
+    }
+
+    /**
+     * Prints a message to ask the user for the field of the item to be updated.
+     */
+    public void askForItemFieldToBeUpdated() {
+        System.out.println(Messages.MESSAGE_ASK_FOR_ITEM_FIELD_TO_BE_UPDATED);
+    }
+
+    /**
+     * Prints a message to ask the user about the revised item price.
+     */
+    public void askForRevisedItemPrice() {
+        System.out.println(Messages.MESSAGE_ASK_FOR_REVISED_ITEM_PRICE);
+    }
+
+    /**
+     * Prints a message to notify the user the item field is updated successfully.
+     */
+    public void showUpdateItemPrice() {
+        System.out.println(Messages.MESSAGE_SHOW_UPDATE_ITEM_PRICE);
+    }
+
+    /**
+     * Prints a message to notify the user that the item field entered is wrong.
+     * This means the user should input either "p" for (item) price
+     * or s for (item) stock.
+     */
+    public void showWrongItemField() {
+        System.out.println(Messages.MESSAGE_WRONG_ITEM_FIELD_COMMAND);
+    }
+
+    /**
+     * Prints a message to notify the user that the input item index is invalid.
+     * This means the user should input a valid number corresponding to the index
+     * in the item list.
+     */
+    public void showInvalidItemIndex() {
+        System.out.println(Messages.MESSAGE_INVALID_ITEM_INDEX);
+    }
+
+    /**
+     * Prints a message to notify the user that the input item index is empty.
+     * This means the user should input a non-empty and
+     * valid number corresponding to the index in the item list.
+     */
+    public void showEmptyItemIndex() {
+        System.out.println(Messages.MESSAGE_EMPTY_ITEM_INDEX);
+    }
+
+    /**
+     * Prints a message to notify the user that the input item index is empty.
+     * This means the user should input a numeric and
+     * valid number corresponding to the index in the item list.
+     */
+    public void showNonNumericItemIndex() {
+        System.out.println(Messages.MESSAGE_NON_NUMERIC_ITEM_INDEX);
+    }
 }


### PR DESCRIPTION
This version of easyLog can update the additional attribute called "price" for all items. The user is able to revise an item price any time at ease. Again, the price should be a number which is between 0 and 1,000,000,000 SGD inclusive. The item list will also display the revised prices for different items in the system.
(Zikun also adds the code base so that other fields can be updated with the same simple logic (e.g., stock).)