### PR TITLE
Add Increment: Update item stock

### DIFF
--- a/src/main/java/seedu/easylog/commands/itemscommands/ItemsUpdateCommand.java
+++ b/src/main/java/seedu/easylog/commands/itemscommands/ItemsUpdateCommand.java
@@ -1,15 +1,22 @@
 package seedu.easylog.commands.itemscommands;
 
 import seedu.easylog.common.Constants;
+
 import seedu.easylog.exceptions.WrongUpdateCommandException;
 import seedu.easylog.exceptions.WrongItemFieldException;
 import seedu.easylog.exceptions.EmptyItemIndexException;
-import seedu.easylog.exceptions.NonNumericItemIndexException;
+import seedu.easylog.exceptions.NonIntegerNumericItemIndexException;
 import seedu.easylog.exceptions.InvalidItemIndexException;
 import seedu.easylog.exceptions.NonNumericItemPriceException;
 import seedu.easylog.exceptions.EmptyItemPriceException;
 import seedu.easylog.exceptions.InvalidItemPriceException;
 import seedu.easylog.exceptions.NullItemPriceException;
+import seedu.easylog.exceptions.NullItemStockException;
+import seedu.easylog.exceptions.EmptyItemStockException;
+import seedu.easylog.exceptions.NonIntegerNumericItemStockException;
+import seedu.easylog.exceptions.InvalidItemStockException;
+
+
 import seedu.easylog.item.ItemManager;
 
 import java.util.regex.Pattern;
@@ -23,8 +30,10 @@ public class ItemsUpdateCommand extends ItemsCommand {
      * @param itemManager      item manager object which modifies items when necessary
      */
     public void execute(String extraDescription, ItemManager itemManager) throws WrongUpdateCommandException,
-            WrongItemFieldException, EmptyItemIndexException, NonNumericItemIndexException, InvalidItemIndexException,
-            NonNumericItemPriceException, EmptyItemPriceException, InvalidItemPriceException, NullItemPriceException {
+            WrongItemFieldException, EmptyItemIndexException, NonIntegerNumericItemIndexException,
+            InvalidItemIndexException, NonNumericItemPriceException, EmptyItemPriceException, InvalidItemPriceException,
+            NullItemPriceException, NullItemStockException, EmptyItemStockException,
+            NonIntegerNumericItemStockException, InvalidItemStockException {
         if (!extraDescription.isEmpty()) {
             throw new WrongUpdateCommandException();
         }
@@ -39,9 +48,9 @@ public class ItemsUpdateCommand extends ItemsCommand {
             throw new EmptyItemIndexException();
         }
 
-        Pattern pattern = Pattern.compile(Constants.REGEX_NUMERIC_INPUT);
-        if (!pattern.matcher(itemIndexInString).matches()) { // If itemIndexInString is not numeric
-            throw new NonNumericItemIndexException();
+        Pattern pattern = Pattern.compile(Constants.REGEX_INT_NUMERIC_INPUT);
+        if (!pattern.matcher(itemIndexInString).matches()) { // If itemIndexInString is not integer numeric
+            throw new NonIntegerNumericItemIndexException();
         }
 
         int itemIndexInInt = Integer.parseInt(itemIndexInString) - Constants.ARRAY_OFFSET;
@@ -55,6 +64,7 @@ public class ItemsUpdateCommand extends ItemsCommand {
         String itemField = Constants.SCANNER.nextLine();
 
         String revisedItemPrice;
+        String revisedItemStock;
 
         if (itemField.equals("p")) {
             ui.askForRevisedItemPrice();
@@ -62,12 +72,20 @@ public class ItemsUpdateCommand extends ItemsCommand {
 
             // Get revised item price while handling all possible exceptions
             revisedItemPrice = itemsPromptPriceCommand.execute();
+            itemManager.setRevisedItemPrice(itemIndexInInt, revisedItemPrice);
+            ui.showUpdateItemPrice();
+        } else if (itemField.equals("s")) {
+            ui.askForRevisedItemStock();
+            ItemsPromptStockCommand itemsPromptStockCommand = new ItemsPromptStockCommand();
+
+            // Get revised item stock while handling all possible exceptions
+            revisedItemStock = itemsPromptStockCommand.execute();
+            itemManager.setRevisedItemStock(itemIndexInInt, revisedItemStock);
+            ui.showUpdateItemStock();
         } else {
             throw new WrongItemFieldException();
         }
 
-        itemManager.setRevisedItemPrice(itemIndexInInt, revisedItemPrice);
 
-        ui.showUpdateItemPrice();
     }
 }

--- a/src/main/java/seedu/easylog/common/Messages.java
+++ b/src/main/java/seedu/easylog/common/Messages.java
@@ -68,18 +68,18 @@ public class Messages {
                     + "to a number having an exact scale of 2.\n"
                     + "Lastly, the system automatically strips trailing zeros, if any.";
     public static final String MESSAGE_SHOW_INVALID_ITEM_PRICE = "OOPS!!! The item price is invalid!\n"
-            + "Please complete the item information! :)";
+            + "Please input again and give a valid item price! :)";
     public static final String MESSAGE_NULL_ITEM_PRICE = "OOPS!!! The input item price is null!\n"
-            + "Please input the item information again! :)";
+            + "Please input again and complete the item price! :)";
     public static final String MESSAGE_EMPTY_ITEM_PRICE = "OOPS!!! The input item price is empty!\n"
-            + "Please input the item information again! :)";
+            + "Please input again and complete the item price! :)";
     public static final String MESSAGE_NON_NUMERIC_ITEM_PRICE = "OOPS!!! The input item price is not a number!\n"
-            + "Please input the item information again! :)";
+            + "Please input again and give a valid item price! :)";
     public static final String MESSAGE_PROMPT_ITEM_STOCK =
             "Please enter the stock of the item.\n"
                     + "Note: The stock to be entered should be either 0 or a positive integer number "
                     + "smaller than or equal to 100000000 "
-                    + "(The warehouse cannot store more than one hundred million items.";
+                    + "(The warehouse cannot store more than one hundred million items.)";
     public static final String MESSAGE_SHOW_INVALID_ITEM_STOCK = "OOPS!!! The item stock is invalid!\n"
             + "Please input again and give a valid item stock! :)";
     public static final String MESSAGE_NULL_ITEM_STOCK = "OOPS!!! The input item stock is null!\n"
@@ -100,10 +100,12 @@ public class Messages {
     public static final String MESSAGE_WRONG_ITEM_FIELD_COMMAND = "OOPS!!! I'm sorry! I don't know what that means.\n"
             + "Please input either \"p\" for (item) price or s for (item) stock.";
     public static final String MESSAGE_INVALID_ITEM_INDEX = "OOPS!!! The item index is invalid!\n"
-            + "Please complete the item information! :)";
+            + "Please input again and give a valid item index! :)";
     public static final String MESSAGE_EMPTY_ITEM_INDEX = "OOPS!!! The item index is empty!\n"
-            + "Please complete the item information! :)";
+            + "Please input again and complete the item index! :)";
     public static final String MESSAGE_NON_NUMERIC_ITEM_INDEX = "OOPS!!! The item index is non-numeric!\n"
-            + "Please complete the item information! :)";
+            + "Please input again and give a valid item index! :)";
+    public static final String MESSAGE_ASK_FOR_REVISED_ITEM_STOCK = "What is the revised item stock?";
+    public static final String MESSAGE_SHOW_UPDATE_ITEM_STOCK = "Done! I just updated the item stock for you.";
 }
 

--- a/src/main/java/seedu/easylog/exceptions/NonIntegerNumericItemIndexException.java
+++ b/src/main/java/seedu/easylog/exceptions/NonIntegerNumericItemIndexException.java
@@ -1,0 +1,5 @@
+package seedu.easylog.exceptions;
+
+public class NonIntegerNumericItemIndexException extends Throwable {
+    // no other code needed
+}

--- a/src/main/java/seedu/easylog/exceptions/NonNumericItemIndexException.java
+++ b/src/main/java/seedu/easylog/exceptions/NonNumericItemIndexException.java
@@ -1,5 +1,0 @@
-package seedu.easylog.exceptions;
-
-public class NonNumericItemIndexException extends Throwable {
-    // no other code needed
-}

--- a/src/main/java/seedu/easylog/item/Item.java
+++ b/src/main/java/seedu/easylog/item/Item.java
@@ -52,4 +52,11 @@ public class Item {
     public void setItemPrice(String itemPrice) {
         this.itemPrice = itemPrice;
     }
+
+    /**
+     * Sets the stock of an item of interest.
+     */
+    public void setItemStock(String itemStock) {
+        this.itemStock = itemStock;
+    }
 }

--- a/src/main/java/seedu/easylog/item/ItemManager.java
+++ b/src/main/java/seedu/easylog/item/ItemManager.java
@@ -104,5 +104,14 @@ public class ItemManager {
         Item itemToBeUpdated = getItem(itemIndex);
         itemToBeUpdated.setItemPrice(revisedItemPrice);
     }
+
+    /**
+     * Sets the stock of an item specified by its index to
+     * be the revised one.
+     */
+    public void setRevisedItemStock(int itemIndex, String revisedItemStock) {
+        Item itemToBeUpdated = getItem(itemIndex);
+        itemToBeUpdated.setItemStock(revisedItemStock);
+    }
 }
 

--- a/src/main/java/seedu/easylog/parser/ItemsParser.java
+++ b/src/main/java/seedu/easylog/parser/ItemsParser.java
@@ -22,7 +22,7 @@ import seedu.easylog.exceptions.ItemListAlreadyClearedException;
 import seedu.easylog.exceptions.WrongUpdateCommandException;
 import seedu.easylog.exceptions.InvalidItemIndexException;
 import seedu.easylog.exceptions.EmptyItemIndexException;
-import seedu.easylog.exceptions.NonNumericItemIndexException;
+import seedu.easylog.exceptions.NonIntegerNumericItemIndexException;
 import seedu.easylog.exceptions.WrongItemFieldException;
 import seedu.easylog.item.ItemManager;
 
@@ -91,7 +91,7 @@ public class ItemsParser extends Parser {
                 ui.showInvalidItemIndex();
             } catch (EmptyItemIndexException e) {
                 ui.showEmptyItemIndex();
-            } catch (NonNumericItemIndexException e) {
+            } catch (NonIntegerNumericItemIndexException e) {
                 ui.showNonNumericItemIndex();
             } catch (EmptyItemPriceException e) {
                 ui.showEmptyItemPrice();
@@ -101,6 +101,14 @@ public class ItemsParser extends Parser {
                 ui.showNonNumericItemPrice();
             } catch (InvalidItemPriceException e) {
                 ui.showInvalidItemPrice();
+            } catch (InvalidItemStockException e) {
+                ui.showInvalidItemStock();
+            } catch (EmptyItemStockException e) {
+                ui.showEmptyItemStock();
+            } catch (NullItemStockException e) {
+                ui.showNullItemStock();
+            } catch (NonIntegerNumericItemStockException e) {
+                ui.showNonIntegerNumericItemStock();
             }
             break;
         default:

--- a/src/main/java/seedu/easylog/ui/Ui.java
+++ b/src/main/java/seedu/easylog/ui/Ui.java
@@ -341,4 +341,18 @@ public class Ui {
     public void showNonNumericItemIndex() {
         System.out.println(Messages.MESSAGE_NON_NUMERIC_ITEM_INDEX);
     }
+
+    /**
+     * Prints a message to ask the user about the revised item stock.
+     */
+    public void askForRevisedItemStock() {
+        System.out.println(Messages.MESSAGE_ASK_FOR_REVISED_ITEM_STOCK);
+    }
+
+    /**
+     * Prints a message to notify the user the item field is updated successfully.
+     */
+    public void showUpdateItemStock() {
+        System.out.println(Messages.MESSAGE_SHOW_UPDATE_ITEM_STOCK);
+    }
 }


### PR DESCRIPTION
This version of easyLog can update the additional attribute called "stock" for all items. The user is able to revise an item stock at any time at ease. Again, the stock should be an integer number which is between 0 and 100 million inclusive. The item list will also display the revised stocks for different items in the system.